### PR TITLE
Bump wait time for querying circleci api

### DIFF
--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -210,7 +210,7 @@ steps:
         echo "This build will block until all previous builds complete."
         echo "Max Queue Time: ${max_time} minutes."
         wait_time=0
-        loop_time=11
+        loop_time=20
         max_time_seconds=$((max_time * 60))
 
         #


### PR DESCRIPTION
Bump the wait time between circleci api queries so we hopefully reduce/eliminate simultaneous deployments

We've experienced simultaneous deployments more frequently recently as the number of devs waiting in the queue increases, and the time between jobs in workflows increases due usually to container spin up times/provisioning. I believe time between jobs is a state not handled by our api queries, so it's considered to be a 'done' state, allowing the next workflow in the queue to proceed

### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
